### PR TITLE
Use tab separator for ArduinoCloud keyword

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Class (KEYWORD1)
 #######################################
 
-ArduinoCloud    KEYWORD1
+ArduinoCloud	KEYWORD1
 ArduinoCloudThing	KEYWORD1
 
 #######################################


### PR DESCRIPTION
Keywords.txt requires a tab separator, not spaces between keyword and keyword type identifier.
