### PR TITLE
Fix spelling in comment

### DIFF
--- a/examples/ReadAndWrite/ReadAndWrite.ino
+++ b/examples/ReadAndWrite/ReadAndWrite.ino
@@ -52,7 +52,7 @@ void setup() {
   }
 
   // setup the "cloudObject"
-  cloudObject.enableDebug(); // eneble the serial debug output
+  cloudObject.enableDebug(); // enable the serial debug output
   cloudObject.begin(thingName, userName, thingId, thingPsw, sslClient);
 
   // define the properties


### PR DESCRIPTION
Comment previously said 'eneble' but that is a spelling error. This pull contains a commit to fix that spelling to 'enable'.